### PR TITLE
Develop

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,4 +25,4 @@ def create_app():
 flask_app = create_app()
 
 if __name__ == "__main__":
-    flask_app.run(debug=True, port=8000)
+    flask_app.run(debug=True, host='0.0.0.0', port=8000)

--- a/hltv_scraper/hltv_scraper/settings.py
+++ b/hltv_scraper/hltv_scraper/settings.py
@@ -17,7 +17,7 @@ NEWSPIDER_MODULE = "hltv_scraper.spiders"
 USER_AGENT = "hltv_scraper (+https://www.hltv.org/)"
 
 # Obey robots.txt rules
-ROBOTSTXT_OBEY = True
+ROBOTSTXT_OBEY = False
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
 # CONCURRENT_REQUESTS = 32

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,4 @@ Werkzeug==3.1.3
 wrapt==1.17.2
 wsproto==1.2.0
 zope.interface==7.2
+cloudscraper==1.2.71


### PR DESCRIPTION
This pull request introduces several changes to improve the flexibility and robustness of the HLTV scraper application. The main updates include enhancing the spider's request strategy to better handle anti-bot protections, modifying the application's network accessibility, and adjusting Scrapy settings for crawling.

**Spider improvements and request handling:**

* Replaced the use of `SeleniumRequest` with `cloudscraper` in `hltv_match.py` to bypass Cloudflare protections more efficiently. Now, requests are first attempted with `cloudscraper`, and if that fails, the spider falls back to a standard Scrapy request. Error handling has been added to log failures when fetching URLs. [[1]](diffhunk://#diff-01320055b306e2821bf737bdda6350044a77f6323e12e255d0c4e2a98f3083c9L3-R4) [[2]](diffhunk://#diff-01320055b306e2821bf737bdda6350044a77f6323e12e255d0c4e2a98f3083c9R17-R29)

**Configuration and deployment updates:**

* Changed the Flask app to listen on all network interfaces (`host='0.0.0.0'`) instead of only localhost, making it accessible from outside the local machine.
* Disabled `ROBOTSTXT_OBEY` in Scrapy settings, allowing the spider to ignore `robots.txt` rules and crawl all pages regardless of site restrictions.