### PR TITLE
Fix: match stats

### DIFF
--- a/hltv_scraper/hltv_scraper/spiders/parsers/player_stats.py
+++ b/hltv_scraper/hltv_scraper/spiders/parsers/player_stats.py
@@ -12,8 +12,8 @@ class PlayerStatsParser(Parser):
             "kd": player.css(".kd::text").get(),
             "+/-": player.css(".plus-minus ::text").get(),
             "adr": player.css(".adr::text").get(),
-            "kast": player.css(".kast::text").get(),
-            "rating 2.0": player.css(".rating::text").get(),
+            "swing": player.css(".roundSwing::text").get(),
+            "rating 3.0": player.css(".rating::text").get(),
         }
         for player in players
     ]

--- a/hltv_scraper/hltv_scraper/spiders/parsers/table_stats.py
+++ b/hltv_scraper/hltv_scraper/spiders/parsers/table_stats.py
@@ -8,7 +8,7 @@ class TableStatsParser(Parser):
         return [
             {
                 "team": table.css(".teamName.team::text").get(),
-                "stats": PlayerStatsParser.parse(table.css("tr[class]:not(.header-row)")),
+                "stats": PlayerStatsParser.parse(table.css("tr:not(.header-row)")),
             }
             for table in table_stats
         ]


### PR DESCRIPTION
This pull request updates the player and team statistics parsing logic to align with new data formats and selectors. The main changes focus on updating the stats fields and improving selector accuracy.

**Player stats field updates:**

* Replaced the `kast` field with `swing`, and updated the rating from `rating 2.0` to `rating 3.0` in the output dictionary of `parse` in `player_stats.py` to match the new data structure.

**Selector improvements:**

* Adjusted the CSS selector in `table_stats.py` to use `tr:not(.header-row)` instead of `tr[class]:not(.header-row)` for more accurate row selection when parsing player stats for each team.